### PR TITLE
Add: zenity mention in Setup section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,8 @@ Setup
 
    pip install passhole
    ph init
+   
+   # install zenity for password prompt 
 
 
 Example Usage


### PR DESCRIPTION
`zenity` used inside `passhole` for password prompting if database is unlocked.
But, `zenity` not mentioned as `passhole`'s optional dependency. There is no *dependencies*
section, so, i added it as shell-comment.

Thanks Evidlo/passhole#37